### PR TITLE
Fix for offset use in LocalDateTime on OpenJDK 11

### DIFF
--- a/modules/agent/src/main/c/agent.c
+++ b/modules/agent/src/main/c/agent.c
@@ -71,9 +71,8 @@ jlong fakeGetNanoTimeAdjustment(JNIEnv *jni_env, jclass klass, jlong offsetInSec
   if (getAbsoluteFromSystemProperty(jni_env, &propertyValue)) {
     return (propertyValue - offsetInSeconds * 1000) * 1000000;
   }
-  
-  if (getOffsetFromSystemProperty(jni_env, &propertyValue)) {
-    return realGetNanoTimeAdjustment(jni_env, klass, offsetInSeconds) + (propertyValue * 1000 * 1000);
+  else if (getOffsetFromSystemProperty(jni_env, &propertyValue)) {
+    return realGetNanoTimeAdjustment(jni_env, klass, offsetInSeconds) + propertyValue * 1000000;
   }
 
   return realGetNanoTimeAdjustment(jni_env, klass, offsetInSeconds);

--- a/modules/agent/src/main/c/agent.c
+++ b/modules/agent/src/main/c/agent.c
@@ -71,6 +71,10 @@ jlong fakeGetNanoTimeAdjustment(JNIEnv *jni_env, jclass klass, jlong offsetInSec
   if (getAbsoluteFromSystemProperty(jni_env, &propertyValue)) {
     return (propertyValue - offsetInSeconds * 1000) * 1000000;
   }
+  
+  if (getOffsetFromSystemProperty(jni_env, &propertyValue)) {
+    return realGetNanoTimeAdjustment(jni_env, klass, offsetInSeconds) + (propertyValue * 1000 * 1000);
+  }
 
   return realGetNanoTimeAdjustment(jni_env, klass, offsetInSeconds);
 }
@@ -119,6 +123,11 @@ void JNICALL onVmInit(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread) {
 
   if (realCurrentTimeMillis == NULL) {
     fprintf(stderr, "FakeTime agent failed to patch currentTimeMillis.\n");
+    return;
+  }
+  
+  if (realGetNanoTimeAdjustment == NULL) {
+    fprintf(stderr, "FakeTime agent failed to patch getNanoTimeAdjustment.\n");
     return;
   }
 }


### PR DESCRIPTION
Enable override of VM nano offset when only offset system property is provided

Noticed `java.time.LocalDateTime` was not showing the override properly due to the "real" VM nano time adjustment (from `VM::getNanoTimeAdjustment`) being applied in `Clock$SystemClock::instant`

Tested using
```
openjdk version "11.0.2" 2019-01-15
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.2+9)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.2+9, mixed mode)
```